### PR TITLE
Added toggle to remove Pokemon that are unselectable in the Stadium games

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "Random Pokemon",
+  "name": "Random-Pokemon-Generator",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/public/dex/johto.json
+++ b/public/dex/johto.json
@@ -1192,7 +1192,7 @@
 			"psychic"
 		],
 		"isLegendary": true,
-		"isNotPickable": true
+		"isStadiumRental": false
 	},
 	{
 		"id": 151,
@@ -1201,7 +1201,7 @@
 			"psychic"
 		],
 		"isLegendary": true,
-		"isNotPickable": true
+		"isStadiumRental": false
 	},
 	{
 		"id": 152,
@@ -2170,7 +2170,7 @@
 			"flying"
 		],
 		"isLegendary": true,
-		"isNotPickable": true
+		"isStadiumRental": false
 	},
 	{
 		"id": 250,
@@ -2180,7 +2180,7 @@
 			"flying"
 		],
 		"isLegendary": true,
-		"isNotPickable": true
+		"isStadiumRental": false
 	},
 	{
 		"id": 251,
@@ -2190,6 +2190,6 @@
 			"grass"
 		],
 		"isLegendary": true,
-		"isNotPickable": true
+		"isStadiumRental": false
 	}
 ]

--- a/public/dex/johto.json
+++ b/public/dex/johto.json
@@ -1191,7 +1191,8 @@
 		"types": [
 			"psychic"
 		],
-		"isLegendary": true
+		"isLegendary": true,
+		"isNotPickable": true
 	},
 	{
 		"id": 151,
@@ -1199,7 +1200,8 @@
 		"types": [
 			"psychic"
 		],
-		"isLegendary": true
+		"isLegendary": true,
+		"isNotPickable": true
 	},
 	{
 		"id": 152,
@@ -2167,7 +2169,8 @@
 			"psychic",
 			"flying"
 		],
-		"isLegendary": true
+		"isLegendary": true,
+		"isNotPickable": true
 	},
 	{
 		"id": 250,
@@ -2176,7 +2179,8 @@
 			"fire",
 			"flying"
 		],
-		"isLegendary": true
+		"isLegendary": true,
+		"isNotPickable": true
 	},
 	{
 		"id": 251,
@@ -2185,6 +2189,7 @@
 			"psychic",
 			"grass"
 		],
-		"isLegendary": true
+		"isLegendary": true,
+		"isNotPickable": true
 	}
 ]

--- a/public/dex/kanto.json
+++ b/public/dex/kanto.json
@@ -1186,7 +1186,7 @@
 			"psychic"
 		],
 		"isLegendary": true,
-		"isNotPickable": true
+		"isStadiumRental": false
 	},
 	{
 		"id": 151,
@@ -1195,6 +1195,6 @@
 			"psychic"
 		],
 		"isLegendary": true,
-		"isNotPickable": true
+		"isStadiumRental": false
 	}
 ]

--- a/public/dex/kanto.json
+++ b/public/dex/kanto.json
@@ -1185,7 +1185,8 @@
 		"types": [
 			"psychic"
 		],
-		"isLegendary": true
+		"isLegendary": true,
+		"isNotPickable": true
 	},
 	{
 		"id": 151,
@@ -1193,6 +1194,7 @@
 		"types": [
 			"psychic"
 		],
-		"isLegendary": true
+		"isLegendary": true,
+		"isNotPickable": true
 	}
 ]

--- a/public/index.html
+++ b/public/index.html
@@ -75,6 +75,7 @@
 
 	<fieldset>
 		<label><input type="checkbox" id="legendaries" name="legendaries" value="true" checked>Legendaries</label>
+		<label><input type="checkbox" id="pickable" name="pickable" value="false" checked><abbr title="Removes Pok&eacute;mon that cannot be selected in Stadium 1/2">Pickable Only</abbr></label>
 
 		<label><input type="checkbox" id="nfes" name="nfes" value="true" checked><abbr title="Pok&eacute;mon that are Not Fully Evolved.">NFEs</abbr></label>
 

--- a/public/index.html
+++ b/public/index.html
@@ -34,8 +34,8 @@
 
 		<select name="region" id="region" required>
 			<option value="all">All Regions</option>
-			<option value="kanto" title="Generation 1 (Red, Blue, and Yellow)">Kanto</option>
-			<option value="johto" title="Generation 2 (Gold, Silver, and Crystal)">Johto</option>
+			<option value="kanto" title="Generation 1 (Red, Blue, and Yellow)" data-stadium="true">Kanto</option>
+			<option value="johto" title="Generation 2 (Gold, Silver, and Crystal)" data-stadium="true">Johto</option>
 			<option value="hoenn" title="Generation 3 (Ruby, Sapphire, and Emerald)">Hoenn</option>
 			<option value="sinnoh" title="Generation 4 (Diamond, Pearl)">Sinnoh</option>
 			<option value="sinnoh_pt" title="Generation 4 (Platinum)">Sinnoh (Platinum)</option>
@@ -75,10 +75,13 @@
 
 	<fieldset>
 		<label><input type="checkbox" id="legendaries" name="legendaries" value="true" checked>Legendaries</label>
-		<label><input type="checkbox" id="pickable" name="pickable" value="false" checked><abbr title="Removes Pok&eacute;mon that cannot be selected in Stadium 1/2">Pickable Only</abbr></label>
 
 		<label><input type="checkbox" id="nfes" name="nfes" value="true" checked><abbr title="Pok&eacute;mon that are Not Fully Evolved.">NFEs</abbr></label>
 
+		<label><input type="checkbox" id="stadiumRentals" name="stadiumRentals" value="true"><abbr title="Only generate Pok&eacute;mon that can be selected as rentals in Stadium 1 or 2.">Stadium Rentals Only</abbr></label>
+	</fieldset>
+
+	<fieldset>
 		<label><input type="checkbox" id="sprites" name="sprites" value="true" checked>Sprites</label>
 		<label><input type="checkbox" id="natures" name="natures" value="true">Natures</label>
 		<label><input type="checkbox" id="forms" name="forms" value="true" checked><abbr title="Allow alternate forms, such as Mega Evolutions.">Forms</abbr></label>

--- a/src/options.ts
+++ b/src/options.ts
@@ -5,7 +5,11 @@ type Options = {
 	region: string;
 	type: string;
 	legendaries: boolean;
-	pickable: boolean;
+	/**
+	 * Whether to only generate Pokémon that can be chosen as rentals. Only relevant for
+	 * Stadium 1 and 2 (Kanto and Johto).
+	 */
+	stadiumRentals: boolean;
 	nfes: boolean;
 	sprites: boolean;
 	natures: boolean;
@@ -19,7 +23,7 @@ function getOptionsFromForm(): Options {
 		region: regionDropdown.value,
 		type: typeDropdown.value,
 		legendaries: legendariesCheckbox.checked,
-		pickable: pickableCheckbox.checked,
+		stadiumRentals: stadiumRentalsCheckbox.checked,
 		nfes: nfesCheckbox.checked,
 		sprites: spritesCheckbox.checked,
 		natures: naturesCheckbox.checked,
@@ -40,8 +44,8 @@ function setOptions(options: Partial<Options>) {
 	if (options.legendaries != null) {
 		legendariesCheckbox.checked = options.legendaries;
 	}
-	if (options.pickable != null) {
-		pickableCheckbox.checked = options.pickable;
+	if (options.stadiumRentals != null) {
+		stadiumRentalsCheckbox.checked = options.stadiumRentals;
 	}
 	if (options.nfes != null) {
 		nfesCheckbox.checked = options.nfes;
@@ -102,8 +106,8 @@ function convertUrlParamsToOptions(): Partial<Options> {
 	if (params.has("legendaries")) {
 		options.legendaries = parseBoolean(params.get("legendaries"));
 	}
-	if (params.has("pickable")) {
-		options.pickable = parseBoolean(params.get("pickable"));
+	if (params.has("stadiumRentals")) {
+		options.stadiumRentals = parseBoolean(params.get("stadiumRentals"));
 	}
 	if (params.has("nfes")) {
 		options.nfes = parseBoolean(params.get("nfes"));
@@ -130,4 +134,15 @@ function convertOptionsToUrlParams(options: Partial<Options>): string {
 			return encodeURIComponent(key) + "=" + encodeURIComponent(value);
 		})
 		.join("&");
+}
+
+function addFormChangeListeners() {
+	regionDropdown.addEventListener("change", toggleStadiumRentals);
+	toggleStadiumRentals();
+}
+
+function toggleStadiumRentals() {
+	const regionOption = regionDropdown.options[regionDropdown.selectedIndex];
+	const shouldShow = regionOption?.dataset?.stadium == "true";
+	stadiumRentalsCheckbox.parentElement.classList.toggle("invisible", !shouldShow);
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -5,6 +5,7 @@ type Options = {
 	region: string;
 	type: string;
 	legendaries: boolean;
+	pickable: boolean;
 	nfes: boolean;
 	sprites: boolean;
 	natures: boolean;
@@ -18,6 +19,7 @@ function getOptionsFromForm(): Options {
 		region: regionDropdown.value,
 		type: typeDropdown.value,
 		legendaries: legendariesCheckbox.checked,
+		pickable: pickableCheckbox.checked,
 		nfes: nfesCheckbox.checked,
 		sprites: spritesCheckbox.checked,
 		natures: naturesCheckbox.checked,
@@ -37,6 +39,9 @@ function setOptions(options: Partial<Options>) {
 	}
 	if (options.legendaries != null) {
 		legendariesCheckbox.checked = options.legendaries;
+	}
+	if (options.pickable != null) {
+		pickableCheckbox.checked = options.pickable;
 	}
 	if (options.nfes != null) {
 		nfesCheckbox.checked = options.nfes;
@@ -96,6 +101,9 @@ function convertUrlParamsToOptions(): Partial<Options> {
 	}
 	if (params.has("legendaries")) {
 		options.legendaries = parseBoolean(params.get("legendaries"));
+	}
+	if (params.has("pickable")) {
+		options.pickable = parseBoolean(params.get("pickable"));
 	}
 	if (params.has("nfes")) {
 		options.nfes = parseBoolean(params.get("nfes"));

--- a/src/pokemon.ts
+++ b/src/pokemon.ts
@@ -8,7 +8,8 @@ interface Pokemon {
 	types: string[];
 	isNfe?: boolean;
 	isLegendary?: boolean;
-	isNotPickable?: boolean;
+	/** Whether this Pokémon can be rented in Stadium 1 or 2. Defaults to true. */
+	isStadiumRental?: boolean;
 	forms?: Form[];
 }
 

--- a/src/pokemon.ts
+++ b/src/pokemon.ts
@@ -8,6 +8,7 @@ interface Pokemon {
 	types: string[];
 	isNfe?: boolean;
 	isLegendary?: boolean;
+	isNotPickable?: boolean;
 	forms?: Form[];
 }
 

--- a/src/random.ts
+++ b/src/random.ts
@@ -2,7 +2,7 @@ const numberDropdown = document.getElementById("n") as HTMLInputElement;
 const regionDropdown = document.getElementById("region") as HTMLInputElement;
 const typeDropdown = document.getElementById("type") as HTMLInputElement;
 const legendariesCheckbox = document.getElementById("legendaries") as HTMLInputElement;
-const pickableCheckbox = document.getElementById("pickable") as HTMLInputElement;
+const stadiumRentalsCheckbox = document.getElementById("stadiumRentals") as HTMLInputElement;
 const nfesCheckbox = document.getElementById("nfes") as HTMLInputElement;
 const spritesCheckbox = document.getElementById("sprites") as HTMLInputElement;
 const naturesCheckbox = document.getElementById("natures") as HTMLInputElement;
@@ -30,6 +30,7 @@ async function generateRandom() {
 function onPageLoad() {
 	loadOptions();
 	toggleHistoryVisibility();
+	addFormChangeListeners();
 }
 document.addEventListener("DOMContentLoaded", onPageLoad);
 
@@ -67,9 +68,9 @@ async function getEligiblePokemon(options: Options): Promise<Pokemon[]> {
 
 function filterByOptions<P extends Pokemon|Form>(pokemonInRegion: P[], options: Options): P[] {
 	return pokemonInRegion.filter((pokemon: Pokemon | Form) => {
-		// Legendary and NFE status are independent of form, so check these before
+		// Legendary, NFE, and Stadium status are independent of form, so check these before
 		// checking forms.
-		if (options.pickable && "isNotPickable" in pokemon && pokemon.isNotPickable) {
+		if (options.stadiumRentals && "isStadiumRental" in pokemon && !pokemon.isStadiumRental) {
 			return false;
 		}
 		if (!options.legendaries && "isLegendary" in pokemon && pokemon.isLegendary) {

--- a/src/random.ts
+++ b/src/random.ts
@@ -2,6 +2,7 @@ const numberDropdown = document.getElementById("n") as HTMLInputElement;
 const regionDropdown = document.getElementById("region") as HTMLInputElement;
 const typeDropdown = document.getElementById("type") as HTMLInputElement;
 const legendariesCheckbox = document.getElementById("legendaries") as HTMLInputElement;
+const pickableCheckbox = document.getElementById("pickable") as HTMLInputElement;
 const nfesCheckbox = document.getElementById("nfes") as HTMLInputElement;
 const spritesCheckbox = document.getElementById("sprites") as HTMLInputElement;
 const naturesCheckbox = document.getElementById("natures") as HTMLInputElement;
@@ -68,6 +69,9 @@ function filterByOptions<P extends Pokemon|Form>(pokemonInRegion: P[], options: 
 	return pokemonInRegion.filter((pokemon: Pokemon | Form) => {
 		// Legendary and NFE status are independent of form, so check these before
 		// checking forms.
+		if (options.pickable && "isNotPickable" in pokemon && pokemon.isNotPickable) {
+			return false;
+		}
 		if (!options.legendaries && "isLegendary" in pokemon && pokemon.isLegendary) {
 			return false;
 		}


### PR DESCRIPTION
One of the large use cases I've seen for your app is in the Pokemon Stadium Rental Rando challenge. 
However, in the Stadium games there are a few Pokemon that are unselectable from the rental pool: 
In Stadium 1 it's Mew/Mewtwo 
In Stadium 2 it's Mew/Mewtwo/Celebi/Ho-Oh/Lugia

When doing the challenge and you roll one of those mons you have to scrap your entire team and roll another one, which can be a bit unfortunate.

I added an additional checkbox that will stop those mons from appearing if it's selected. 
I tried to follow all the existing conventions you had and keep everything on par. 

If you see something you don't like or even just aren't interested in this change, no worries just let me know! 

Thanks for taking a look at this.
